### PR TITLE
Updates such that QuantileRegression.jl is up to date with Base, GLM and...

### DIFF
--- a/examples/qreg_example.jl
+++ b/examples/qreg_example.jl
@@ -1,61 +1,31 @@
-using GLM, QuantileRegression
+using GLM, QuantileRegression, Gadfly
 
 # Load data
 url = "http://vincentarelbundock.github.io/Rdatasets/csv/quantreg/engel.csv"
 # TODO: Make automatic URL downloads work
 dat = readtable("engel.csv")
 
-# Fit least absolute deviation model (quantile =.5)
-res = qreg(:(foodexp~income), dat, .5)
-describe(res)
-
+# Fit least absolute deviation model (quantile  = .5)
+res = qreg(foodexp~income, dat, .5)
+coefs = coeftable(res)
+show(coefs)
 # Fit quantile regression for a bunch of different quantiles
-dat_plot = [summary(qreg(:(foodexp ~ income), dat, i/10))[2,:] for i in 1:9]
-dat_plot = reduce(vcat, dat_plot)
+data_plot = reduce(vcat,[coeftable(qreg(foodexp ~ income, dat, i/20)).mat[2,1:2] for i in 1:19])
 
 # Fit OLS model to compare
-res_lm = lm(:(foodexp~income), dat)
-ols = coeftable(res_lm)[2,1]
-ols = rep(ols, 9)
+res_lm = lm(foodexp~income, dat)
+ols = reduce(vcat,rep(coeftable(res_lm).mat[2,1:2],19))
 
-# Plot results
-using Winston
+Ydata = [ols[:,1];data_plot[:,1]]
+Yse   = [ols[:,2];data_plot[:,2]]
 
-x = [i/10 for i=1:9]
-y = dat_plot["Estimate"]
-p = FramedPlot()
-add(p, Curve(x, dat_plot["Estimate"]))
-add(p, Curve(x, dat_plot["2.5%"], "type", "dash"))
-add(p, Curve(x, dat_plot["97.5%"], "type", "dash"))
-add(p, Curve(x, ols, "color", "red"))
-setattr(p, "title", "Quantile regression: Food Expenditure ~ Income\n Red bar: OLS coefficient")
-setattr(p, "xlabel", "Quantiles")
-setattr(p, "ylabel", "Coefficient on Income")
-file(p, "/Users/USERNAME/qreg_example_plot.png")
+PlotDataFrame =  DataFrame(X = [linspace(1,19,19)/20;linspace(1,19,19)/20],
+                         Y = Ydata,
+                         Ymin = Ydata - 1.96 * Yse,
+                         Ymax = Ydata + 1.96 * Yse, 
+                         Estimator = [["OLS" for i = 1:19];["Q(0.5)" for i = 1:19]])
 
-# > summary(res)
-# 2x5 DataFrame:
-#         Estimate Std.Error t value     2.5%    97.5%
-# [1,]     81.4823   14.6345 5.56783  52.7987  110.166
-# [2,]    0.560181 0.0131756 42.5164 0.534356 0.586005
-# insheet using engel.csv
-# qreg foodexp income, vce(iid, kernel(epan2))
- 
-# . qreg foodexp income, vce(iid, kernel(epan2))
-# Iteration  1:  WLS sum of weighted deviations =  18051.196
-# 
-# Iteration  1: sum of abs. weighted deviations =  18035.127
-# Iteration  2: sum of abs. weighted deviations =  17815.249
-# Iteration  3: sum of abs. weighted deviations =  17567.085
-# Iteration  4: sum of abs. weighted deviations =  17559.932
-# 
-# Median regression                                    Number of obs =       235
-#   Raw sum of deviations 46278.06 (about 582.54126)
-#   Min sum of deviations 17559.93                     Pseudo R2     =    0.6206
-# 
-# ------------------------------------------------------------------------------
-#      foodexp |      Coef.   Std. Err.      t    P>|t|     [95% Conf. Interval]
-# -------------+----------------------------------------------------------------
-#       income |   .5601805   .0131763    42.51   0.000     .5342206    .5861403
-#        _cons |   81.48233   14.63518     5.57   0.000     52.64815    110.3165
-# ------------------------------------------------------------------------------
+plot(layer(PlotDataFrame, x = "X", y = "Ymin",Geom.line,color = "Estimator"),
+     layer(PlotDataFrame, x = "X", y = "Ymax",Geom.line,color = "Estimator"),
+     layer(PlotDataFrame, x = "X", y = "Y", color = "Estimator",Geom.line), 
+     Guide.XLabel("Income"), Guide.YLabel("Food Expenditure"))


### PR DESCRIPTION
... DataFrames

As discussed via E-mail with @vincentarelbundock . I've tried to make QuantileRegression.jl a bit more up to date. The previous version didn't run under 0.3.6, as some changes had been made in Base.At_mul_B, GLM, and DataFrames.

Some changes:
Changed from xtxi = pinv to xtx combined with \ and /.
Deleted maxdiff and replaced with the new norm function.
Updated syntax.
Cleaned/fixed qreg_example.jl so it runs again.